### PR TITLE
Changed the name of the extension used for BOM generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ publishing {
 	publications {
 	    parent(MavenPublication) {
 	        // the transitive closure of this configuration will be flattened and added to the dependency management section
-	        dependencyManagement.fromConfigurations { configurations.compile }
+	        bomGenerator.fromConfigurations { configurations.compile }
 
 	        // alternative syntax when you want to explicitly add a dependency with no transitives
-	        dependencyManagement.withDependencies { 'manual:dep:1' }
+	        bomGenerator.withDependencies { 'manual:dep:1' }
 
 		// the bom will be generated with dependency coordinates of netflix:module-parent:1
 	        artifactId = 'module-parent'

--- a/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
@@ -65,7 +65,7 @@ public class DependencyRecommendationsPlugin implements Plugin<Project> {
     }
 
     protected void enhancePublicationsWithBomProducer(Project project) {
-        project.getExtensions().create("dependencyManagement", MavenBomXmlGenerator.class, project);
+        project.getExtensions().create("bomGenerator", MavenBomXmlGenerator.class, project);
     }
 
     /**

--- a/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginSpec.groovy
+++ b/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginSpec.groovy
@@ -56,8 +56,8 @@ class DependencyRecommendationsPluginSpec extends IntegrationSpec  {
             publishing {
                 publications {
                     parent(MavenPublication) {
-                        dependencyManagement.fromConfigurations { configurations.compile }
-                        dependencyManagement.withDependencies { 'manual:dep:1' }
+                        bomGenerator.fromConfigurations { configurations.compile }
+                        bomGenerator.withDependencies { 'manual:dep:1' }
 
                         artifactId = 'module-parent'
                         pom.withXml { asNode().appendNode('description', 'A demonstration of maven POM customization') }


### PR DESCRIPTION
Changed the name of the extension from `dependencyManagement` to `bomGenerator`. This removes a conflict with the spring boot plugin that was also trying to create an extension with that name. There were two tests failing for me locally before the change, and the same two tests fail in the same way after the change.
