### PR TITLE
Fix README BOM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ publishing {
     publications {
         parent(MavenPublication) {
             // the transitive closure of this configuration will be flattened and added to the dependency management section
-            dependencyManagement.fromConfigurations { configurations.compile }
+            nebulaDependencyManagement.fromConfigurations { configurations.compile }
 
             // alternative syntax when you want to explicitly add a dependency with no transitives
-            dependencyManagement.withDependencies { 'manual:dep:1' }
+            nebulaDependencyManagement.withDependencies { 'manual:dep:1' }
 
             // the bom will be generated with dependency coordinates of netflix:module-parent:1
             artifactId = 'module-parent'


### PR DESCRIPTION
Correct an error in the README's BOM example to reference nebulaDependencyManagement rather than dependencyManagement.