### PR TITLE
Reduce logging level to debug for recommendations

### DIFF
--- a/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
@@ -92,7 +92,7 @@ public class DependencyRecommendationsPlugin implements Plugin<Project> {
                                         if (strategy.recommendVersion(details, version)) {
                                             String coordinate = requested.getGroup() + ":" + requested.getName();
                                             dependencyInsight.addRecommendation(conf.getName(), coordinate, version, whichStrategy(strategy), "nebula.dependency-recommender");
-                                            logger.info("Recommending version " + version + " for dependency " + coordinate);
+                                            logger.debug("Recommending version " + version + " for dependency " + coordinate);
                                         } else {
                                             if (recommendationProviderContainer.isStrictMode()) {
                                                 String errorMessage = "Dependency " + details.getRequested().getGroup() + ":" + details.getRequested().getName() + " omitted version with no recommended version. General causes include a dependency being removed from the recommendation source or not applying a recommendation source to a project that depends on another project using a recommender.";

--- a/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginMultiprojectSpec.groovy
+++ b/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginMultiprojectSpec.groovy
@@ -60,7 +60,7 @@ class DependencyRecommendationsPluginMultiprojectSpec extends IntegrationSpec {
             }
             """.stripIndent()
         when:
-        def results = runTasksSuccessfully(':a:dependencies', ':b:dependencies', 'build')
+        def results = runTasksSuccessfully(':a:dependencies', ':b:dependencies', 'build', '--debug')
 
         then:
         noExceptionThrown()


### PR DESCRIPTION
Can we reduce this to debug level? Info is surprisingly spamming, the first 5538 lines of our CI builds are dependency recommendations.