### PR TITLE
Add thread safety for glob initialization.

### DIFF
--- a/src/main/groovy/netflix/nebula/dependency/recommender/provider/FuzzyVersionResolver.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/provider/FuzzyVersionResolver.java
@@ -23,14 +23,12 @@ public abstract class FuzzyVersionResolver {
         if(version != null) return resolveVersion(version);
 
         if(globs == null) {
-            // initialize glob cache
-            globs = new ArrayList<>();
-            for (String name : propertyNames()) {
-                if(name.contains("*")) {
-                    globs.add(Glob.compile(name, propertyValue(name)));
+            // thread safety for parallel builds
+            synchronized (this) {
+                if(globs == null) {
+                    initializeGlobCache();
                 }
             }
-            Collections.sort(globs);
         }
 
         for (Glob glob : globs) {
@@ -40,6 +38,16 @@ public abstract class FuzzyVersionResolver {
         }
 
         return null;
+    }
+
+    private void initializeGlobCache() {
+        globs = new ArrayList<>();
+        for (String name : propertyNames()) {
+            if(name.contains("*")) {
+                globs.add(Glob.compile(name, propertyValue(name)));
+            }
+        }
+        Collections.sort(globs);
     }
 
     private static class Glob implements Comparable<Glob> {


### PR DESCRIPTION
In a parallel build environment, it is possible for multiple projects
to request the version of the same exact key. In this scenario, both
could try to initialize the glob cache at the same time, and the first
one to finish then immediately tries to iterate over the globs while
the other one is still initializing, causing a concurrent modification
exception.

Targets #27.