### PR TITLE
Feature flag implementation to delegate to IMPROVED_POM_SUPPORT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,17 +26,11 @@ contacts {
     }
 }
 
-repositories {
-    jcenter()
-    maven { url 'https://jitpack.io' } // for xmlunit2
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' } // for xmlunit2
-}
-
 dependencies {
     compile 'com.netflix.nebula:nebula-gradle-interop:latest.release'
     compile 'org.apache.maven:maven-model-builder:3.+'
     testCompile('com.netflix.nebula:nebula-test:latest.release')
-    testCompile('com.github.xmlunit:xmlunit:7ed02fb294') {
+    testCompile ('org.xmlunit:xmlunit-core:2.6.0') {
         exclude module: 'hamcrest-core'
     }
 }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -5,7 +5,7 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
         }
     },
@@ -15,7 +15,7 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
         }
     },
@@ -25,15 +25,11 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
         }
     },
     "integTestCompile": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -43,15 +39,15 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     },
     "integTestCompileClasspath": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -61,15 +57,15 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     },
     "integTestRuntime": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -79,15 +75,15 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     },
     "integTestRuntimeClasspath": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -97,8 +93,12 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     },
     "jacocoAgent": {
@@ -117,7 +117,7 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
         }
     },
@@ -127,15 +127,11 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
         }
     },
     "testCompile": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -145,15 +141,15 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     },
     "testCompileClasspath": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -163,15 +159,15 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     },
     "testRuntime": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -181,15 +177,15 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     },
     "testRuntimeClasspath": {
-        "com.github.xmlunit:xmlunit": {
-            "locked": "7ed02fb294",
-            "requested": "7ed02fb294"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "0.5.0",
             "requested": "latest.release"
@@ -199,8 +195,12 @@
             "requested": "latest.release"
         },
         "org.apache.maven:maven-model-builder": {
-            "locked": "3.5.2",
+            "locked": "3.5.4",
             "requested": "3.+"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.6.0",
+            "requested": "2.6.0"
         }
     }
 }

--- a/src/main/groovy/netflix/nebula/dependency/recommender/ExtendRecommenderConfigurationAction.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/ExtendRecommenderConfigurationAction.java
@@ -1,0 +1,33 @@
+package netflix.nebula.dependency.recommender;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+
+import java.util.Set;
+
+public class ExtendRecommenderConfigurationAction implements Action<Configuration> {
+    private final Configuration bom;
+    private final Set<String> excludedConfigurationNames;
+    private final Project project;
+
+    public ExtendRecommenderConfigurationAction(Configuration bom, Set<String> excludedConfigurationNames, Project project) {
+        this.bom = bom;
+        this.excludedConfigurationNames = excludedConfigurationNames;
+        this.project = project;
+    }
+
+    @Override
+    public void execute(Configuration files) {
+        if (excludedConfigurationNames.contains(files.getName())) {
+            return;
+        }
+        Configuration toExtend = bom;
+        if (!project.getRootProject().equals(project)) {
+            toExtend = bom.copy();
+            toExtend.setVisible(false);
+            project.getConfigurations().add(toExtend);
+        }
+        files.extendsFrom(toExtend);
+    }
+}

--- a/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginCompositeCoreBomSupportSpec.groovy
+++ b/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginCompositeCoreBomSupportSpec.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package netflix.nebula.dependency.recommender
+
+import nebula.test.IntegrationSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.maven.ArtifactType
+import nebula.test.dependencies.maven.Pom
+import nebula.test.dependencies.repositories.MavenRepo
+
+class DependencyRecommendationsPluginCompositeCoreBomSupportSpec extends IntegrationSpec {
+    def repo
+    def generator
+
+    def setup() {
+        fork = true
+        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreBomSupport=true"
+
+        settingsFile << """\
+            enableFeaturePreview('IMPROVED_POM_SUPPORT')
+            """.stripIndent()
+
+        generateRepoIn(projectDir)
+    }
+
+    private void generateRepoIn(File projectDir) {
+        repo = new MavenRepo()
+        repo.root = new File(projectDir, 'build/bomrepo')
+        def pom = new Pom('test.nebula.bom', 'testbom', '1.0.0', ArtifactType.POM)
+        pom.addManagementDependency('test.nebula', 'foo', '1.0.0')
+        repo.poms.add(pom)
+        repo.generate()
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:foo:1.0.0')
+                .build()
+        generator = new GradleDependencyGenerator(graph)
+        generator.generateTestMavenRepo()
+    }
+
+    def 'can use recommender in a composite'() {
+        def a = addSubproject('a', '''\
+                dependencies {
+                    compile 'test.nebula:foo'
+                }
+            '''.stripIndent())
+        writeHelloWorld('a', a)
+        def b = addSubproject('b', '''\
+                dependencies {
+                    compile project(':a')
+                }
+            '''.stripIndent())
+        writeHelloWorld('b', b)
+
+        buildFile << """\
+            apply plugin: 'nebula.dependency-recommender'
+            dependencyRecommendations {
+                mavenBom module: 'test.nebula.bom:testbom:latest.release'
+            }
+            
+            allprojects {
+                group 'example'
+                apply plugin: 'java'
+
+                repositories {
+                    maven { url '${repo.root.absoluteFile.toURI()}' }
+                    ${generator.mavenRepositoryBlock}
+                }
+            }
+            """.stripIndent()
+
+        def compositeDir = new File(projectDir.parentFile, "${projectDir.name}-composite")
+        compositeDir.deleteDir()
+        projectDir.renameTo(compositeDir)
+        projectDir.mkdirs()
+        generateRepoIn(projectDir)
+        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreBomSupport=true"
+
+        // Composite
+        buildFile << """\
+            apply plugin: 'java'
+            apply plugin: 'nebula.dependency-recommender'
+
+            dependencyRecommendations {
+                mavenBom module: 'test.nebula.bom:testbom:latest.release'
+            }
+
+            repositories {
+                maven { url '${repo.root.absoluteFile.toURI()}' }
+                ${generator.mavenRepositoryBlock}
+            }
+
+            dependencies {
+                compile 'example:b:1.0.0'
+            }
+        """.stripIndent()
+        settingsFile << """\
+            rootProject.name = 'composite'
+            includeBuild '$compositeDir'
+            enableFeaturePreview('IMPROVED_POM_SUPPORT')
+        """
+        writeHelloWorld('c')
+
+        when:
+        def results = runTasksSuccessfully(':dependencies')
+
+        then:
+        noExceptionThrown()
+        results.standardOutput.contains 'Found project \'project :can-use-recommender-in-a-composite:b\' as substitute for module \'example:b\'.'
+        results.standardOutput.contains '+--- example:b:1.0.0 -> project :can-use-recommender-in-a-composite:b'
+        results.standardOutput.contains '|    +--- project :can-use-recommender-in-a-composite:a'
+        results.standardOutput.contains '|    |    +--- test.nebula:foo -> 1.0.0'
+    }
+}

--- a/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginCoreBomSupportSpec.groovy
+++ b/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginCoreBomSupportSpec.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package netflix.nebula.dependency.recommender
+
+import nebula.test.IntegrationSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.maven.ArtifactType
+import nebula.test.dependencies.maven.Pom
+import nebula.test.dependencies.repositories.MavenRepo
+import spock.lang.Unroll
+
+class DependencyRecommendationsPluginCoreBomSupportSpec extends IntegrationSpec {
+    def repo
+    def generator
+
+    def setup() {
+        fork = true
+        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreBomSupport=true"
+
+        settingsFile << """\
+            enableFeaturePreview('IMPROVED_POM_SUPPORT')
+            """.stripIndent()
+
+        repo = new MavenRepo()
+        repo.root = new File(projectDir, 'build/bomrepo')
+        def pom = new Pom('test.nebula.bom', 'testbom', '1.0.0', ArtifactType.POM)
+        pom.addManagementDependency('test.nebula', 'foo', '1.0.0')
+        pom.addManagementDependency('test.nebula', 'bar', '2.0.0')
+        pom.addManagementDependency('test.nebula', 'baz', '2.5.0')
+        pom.addManagementDependency('test.nebula', 'lib', '3.9.9')
+        repo.poms.add(pom)
+        repo.generate()
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:foo:1.0.0')
+                .addModule('test.nebula:bar:2.0.0')
+                .addModule('test.nebula:baz:2.5.0')
+                .addModule('test.nebula:lib:3.9.9')
+                .build()
+        generator = new GradleDependencyGenerator(graph)
+        generator.generateTestMavenRepo()
+    }
+
+    def 'add given bom to configs'() {
+        buildFile << """\
+            apply plugin: 'nebula.dependency-recommender'
+            apply plugin: 'java'
+            apply plugin: 'war'
+
+            repositories {
+                maven { url '${repo.root.absoluteFile.toURI()}' }
+                ${generator.mavenRepositoryBlock}
+            }
+
+            dependencyRecommendations {
+                mavenBom module: 'test.nebula.bom:testbom:latest.release'
+            }
+
+            dependencies {
+                annotationProcessor 'test.nebula:bar'
+                compile 'test.nebula:foo'
+                providedCompile 'test.nebula:lib'
+                runtimeOnly 'test.nebula:baz'
+            }
+            """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully('dependencies')
+
+        then:
+        result.standardOutput.contains("+--- test.nebula:foo -> 1.0.0")
+        result.standardOutput.contains("+--- test.nebula:bar -> 2.0.0")
+        result.standardOutput.contains("\\--- test.nebula:baz -> 2.5.0")
+        result.standardOutput.contains("\\--- test.nebula:lib -> 3.9.9")
+    }
+
+    @Unroll
+    def 'error when #type(#argType) used'() {
+        given:
+        buildFile << """\
+            apply plugin: 'nebula.dependency-recommender'
+            apply plugin: 'java'
+
+            dependencyRecommendations {
+                $type $arg
+            }
+            """.stripIndent()
+
+        when:
+        def result = runTasksWithFailure('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        result.standardOutput.contains("> dependencyRecommender.$type is not available with 'systemProp.nebula.features.coreBomSupport=true'")
+
+        where:
+        type             | argType   | arg
+        'map'            | '[:]'     | "recommendations: ['test.nebula:foo': '1.0.0']"
+        'map'            | '{}'      | "{ [recommendations: ['test.nebula:foo': '1.0.0']] }"
+        'dependencyLock' | '[:]'     | "module: 'sample:dependencies:1.0'"
+        'dependencyLock' | '{}'      | "{ [module: 'sample:dependencies:1.0'] }"
+        'ivyXml'         | '[:]'     | "module: 'sample:sample:1.0'"
+        'ivyXml'         | '{}'      | "{ [module: 'sample:sample:1.0'] }"
+        'propertiesFile' | '[:]'     | "file: 'recommendations.props'"
+        'propertiesFile' | '{}'      | "{ [file: 'recommendations.props'] }"
+        'addProvider'    | '{}'      | "{ org, name -> 'latest.release' }"
+    }
+}

--- a/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginMultiprojectCoreBomSupportSpec.groovy
+++ b/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginMultiprojectCoreBomSupportSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package netflix.nebula.dependency.recommender
+
+import nebula.test.IntegrationSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.ModuleBuilder
+import nebula.test.dependencies.maven.ArtifactType
+import nebula.test.dependencies.maven.Pom
+import nebula.test.dependencies.repositories.MavenRepo
+
+class DependencyRecommendationsPluginMultiprojectCoreBomSupportSpec extends IntegrationSpec {
+    def repo
+    def generator
+
+    def setup() {
+        fork = true
+        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreBomSupport=true"
+
+        settingsFile << """\
+            enableFeaturePreview('IMPROVED_POM_SUPPORT')
+            """.stripIndent()
+
+        repo = new MavenRepo()
+        repo.root = new File(projectDir, 'build/bomrepo')
+        def pom = new Pom('test.nebula.bom', 'testbom', '1.0.0', ArtifactType.POM)
+        pom.addManagementDependency('test.nebula', 'foo', '1.0.0')
+        repo.poms.add(pom)
+        repo.generate()
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:foo:1.0.0')
+                .build()
+        generator = new GradleDependencyGenerator(graph)
+        generator.generateTestMavenRepo()
+    }
+
+    def 'can use recommender across a multiproject'() {
+        def a = addSubproject('a', '''\
+                dependencies {
+                    compile 'test.nebula:foo'
+                }
+            '''.stripIndent())
+        writeHelloWorld('a', a)
+        def b = addSubproject('b', '''\
+                dependencies {
+                    compile project(':a')
+                }
+            '''.stripIndent())
+        writeHelloWorld('b', b)
+        buildFile << """\
+            apply plugin: 'nebula.dependency-recommender'
+            dependencyRecommendations {
+                mavenBom module: 'test.nebula.bom:testbom:latest.release'
+            }
+            
+            allprojects {
+                apply plugin: 'java'
+
+                repositories {
+                    maven { url '${repo.root.absoluteFile.toURI()}' }
+                    ${generator.mavenRepositoryBlock}
+                }
+            }
+            """.stripIndent()
+        when:
+        def results = runTasksSuccessfully(':a:dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        results.standardOutput.contains("+--- test.nebula:foo -> 1.0.0")
+    }
+}


### PR DESCRIPTION
If the nebula.features.coreBomSupport feature flag is enabled, the user is expected to add enableFeaturePreview('IMPROVED_POM_SUPPORT') to settings.gradle. The nebulaRecommenderBom configuration will have almost every configuration extend from it (exceptions: provided, nebulaRecommenderBom, archives) so bom dependency versions are available in all the usual places users define dependencies.

For subprojects, the nebulaRecommenderBom configuration will be copied to that project and almost every configuration will extendFrom the copied configuration.