### PR TITLE
Return back to eagerly resolve all recommendation

### DIFF
--- a/src/integTest/groovy/netflix/nebula/dependency/recommender/publisher/MavenBomXmlGeneratorIntegrationSpec.groovy
+++ b/src/integTest/groovy/netflix/nebula/dependency/recommender/publisher/MavenBomXmlGeneratorIntegrationSpec.groovy
@@ -64,63 +64,11 @@ class MavenBomXmlGeneratorIntegrationSpec extends IntegrationSpec {
             """.stripIndent()
 
         when:
-        def results = runTasksSuccessfully('generatePomFileForRecommenderPublication')
+        def results = runTasks('generatePomFileForRecommenderPublication')
 
         then:
         def xml = new File(projectDir, 'build/publications/recommender/pom-default.xml')
         def reader = new XmlSlurper().parse(xml)
-        reader.dependencyManagement.dependencies.dependency.size() == 1
-        reader.dependencyManagement.dependencies.dependency.groupId.text() == 'test0'
-        reader.dependencyManagement.dependencies.dependency.artifactId.text() == 'test0'
-        reader.dependencyManagement.dependencies.dependency.version.text() == '1.0.0'
-    }
-
-    def 'pom created when dependency is missing'() {
-        def graph = new DependencyGraphBuilder().addModule('test0:test0:1.0.0')
-                .build()
-        def generator = new GradleDependencyGenerator(graph, "$projectDir/mytestrepo")
-        generator.generateTestMavenRepo()
-        buildFile << """\
-            plugins {
-                id 'nebula.maven-publish' version '5.1.0'
-            }
-            
-            apply plugin: 'nebula.dependency-recommender'
-            
-            group = 'test.nebula'
-            version = '0.1.0'
-            
-            repositories {
-                ${generator.mavenRepositoryBlock}
-            }
-            
-            configurations {
-                recommendation
-            }
-            
-            dependencies {
-                recommendation 'test0:test0:1.0.0'
-                recommendation 'test1:test1:1.0.0'
-            }
-            
-            publishing {
-                publications {
-                    recommender(MavenPublication) {
-                        project.nebulaDependencyManagement.fromConfigurations {
-                            project.configurations.recommendation
-                        }
-                    }
-                }
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksSuccessfully('generatePomFileForRecommenderPublication')
-
-        then:
-        def xml = new File(projectDir, 'build/publications/recommender/pom-default.xml')
-        def reader = new XmlSlurper().parse(xml)
-        reader.dependencyManagement.dependencies.size() == 1
         reader.dependencyManagement.dependencies.dependency.size() == 1
         reader.dependencyManagement.dependencies.dependency.groupId.text() == 'test0'
         reader.dependencyManagement.dependencies.dependency.artifactId.text() == 'test0'
@@ -169,7 +117,7 @@ class MavenBomXmlGeneratorIntegrationSpec extends IntegrationSpec {
             """.stripIndent()
 
         when:
-        def results = runTasksSuccessfully('generatePomFileForRecommenderPublication')
+        def results = runTasks('generatePomFileForRecommenderPublication')
 
         then:
         def xml = new File(projectDir, 'build/publications/recommender/pom-default.xml')
@@ -223,7 +171,7 @@ class MavenBomXmlGeneratorIntegrationSpec extends IntegrationSpec {
             """.stripIndent()
 
         when:
-        def results = runTasksSuccessfully('generatePomFileForRecommenderPublication')
+        def results = runTasks('generatePomFileForRecommenderPublication')
 
         then:
         def xml = new File(projectDir, 'build/publications/recommender/pom-default.xml')

--- a/src/main/groovy/netflix/nebula/dependency/recommender/publisher/MavenBomXmlGenerator.groovy
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/publisher/MavenBomXmlGenerator.groovy
@@ -78,7 +78,7 @@ class MavenBomXmlGenerator {
     }
 
     protected static Set<ModuleVersionIdentifier> getManagedDependencies(Configuration configuration) {
-        getManagedDependenciesRecursive(configuration.resolvedConfiguration.lenientConfiguration.firstLevelModuleDependencies,
+        getManagedDependenciesRecursive(configuration.resolvedConfiguration.firstLevelModuleDependencies,
                 new HashSet<ModuleVersionIdentifier>())
     }
 


### PR DESCRIPTION
Lenient configuration could cause that dependencies were silently droped and left out of the recommendation.

That would hapen even during transient error during resolution. The publishing will now fail if not all dependencies are resolved.