### PR TITLE
Update exclusions from recommendations

### DIFF
--- a/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
@@ -58,7 +58,7 @@ public class DependencyRecommendationsPlugin implements Plugin<Project> {
         if (CORE_BOM_SUPPORT_ENABLED) {
             logger.warn("coreBomSupport feature enabled");
             recommendationProviderContainer.excludeConfigurations("archives", NEBULA_RECOMMENDER_BOM, "provided",
-                    "versionManagement", "resolutionRules");
+                    "versionManagement", "resolutionRules", "bootArchives", "webapp");
             applyRecommendationsDirectly(project, bomConfiguration);
         } else {
             applyRecommendations(project);


### PR DESCRIPTION
With `nebula.features.coreBomSupport=true`, every configuration except those excluded `extendsFrom` the `nebulaRecommenderBom` configuration. In practice, this means each extended configuration has a dependency on the BOM that shows up in the lock.

This change adds two additional configurations that wouldn't expect to get recommendations to the exclusions and will reduce the noise in the lock.