### PR TITLE
make sure we ignore configurations for spotbugs and findbugs

### DIFF
--- a/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
@@ -60,8 +60,8 @@ public class DependencyRecommendationsPlugin implements Plugin<Project> {
         if (CORE_BOM_SUPPORT_ENABLED) {
             logger.info(project.getName() + ":coreBomSupport feature enabled");
             recommendationProviderContainer.excludeConfigurations("archives", NEBULA_RECOMMENDER_BOM, "provided",
-                    "versionManagement", "resolutionRules", "bootArchives", "webapp", "checkstyle", "jacocoAgent", "jacocoAnt", "pmd", "findbugs", "spotbugs", "cobertura");
-            recommendationProviderContainer.excludeConfigurationPrefixes(SCALA_ANALYSIS_CONFIGURATION_PREFIX);
+                    "versionManagement", "resolutionRules", "bootArchives", "webapp", "checkstyle", "jacocoAgent", "jacocoAnt", "pmd", "cobertura");
+            recommendationProviderContainer.excludeConfigurationPrefixes(SCALA_ANALYSIS_CONFIGURATION_PREFIX, "spotbugs", "findbugs");
             applyRecommendationsDirectly(project, bomConfiguration);
         } else {
             applyRecommendations(project);


### PR DESCRIPTION
Turns out, we were ignoring `spotbugs` configuration but we forgot `spotbugsPlugins`. Same for findbugs