### PR TITLE
Mark copied configurations as non-resolvable so that we do not lock copies of BOM configurations

### DIFF
--- a/src/main/groovy/netflix/nebula/dependency/recommender/ExtendRecommenderConfigurationAction.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/ExtendRecommenderConfigurationAction.java
@@ -32,6 +32,7 @@ public class ExtendRecommenderConfigurationAction implements Action<Configuratio
             if (!project.getRootProject().equals(project)) {
                 toExtend = bom.copy();
                 toExtend.setVisible(false);
+                toExtend.setCanBeResolved(false);
                 project.getConfigurations().add(toExtend);
             }
             configuration.extendsFrom(toExtend);


### PR DESCRIPTION
Based off of a change to use unique configuration names when making copies: https://github.com/gradle/gradle/pull/9638/files