### PR TITLE
make sure we do not apply recommendations for provided versions by Gradle

### DIFF
--- a/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
@@ -64,6 +64,8 @@ public class DependencyRecommendationsPlugin implements Plugin<Project> {
             recommendationProviderContainer.excludeConfigurationPrefixes(SCALA_ANALYSIS_CONFIGURATION_PREFIX, "spotbugs", "findbugs");
             applyRecommendationsDirectly(project, bomConfiguration);
         } else {
+            recommendationProviderContainer.excludeConfigurations("zinc", "checkstyle", "jacocoAgent", "jacocoAnt");
+            recommendationProviderContainer.excludeConfigurationPrefixes(SCALA_ANALYSIS_CONFIGURATION_PREFIX, "spotbugs", "findbugs");
             applyRecommendations(project);
             enhanceDependenciesWithRecommender(project);
         }


### PR DESCRIPTION
The idea behind this is to prevent recommendations for `zinc`

The reason for this is that Gradle provides `zinc` compiler which work with specific versions of Scala. 

When the `zinc` configuration is modified by recommendations, it is possible that the recommendaitons introduce a version of Scala that is not compatible with the zinc version provided by gradle.

This dates to https://issues.gradle.org/browse/GRADLE-3443?focusedCommentId=21175&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21175

Same applies for things like jacoco, spotbugs, checkstyle, etc.

