### PR TITLE
Modernize plugin: remove technical debt and adopt Provider API

### DIFF
--- a/src/main/groovy/netflix/nebula/dependency/recommender/ExtendRecommenderConfigurationAction.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/ExtendRecommenderConfigurationAction.java
@@ -40,7 +40,7 @@ public class ExtendRecommenderConfigurationAction implements Action<Configuratio
 
     @Override
     public void execute(Configuration configuration) {
-        if (!isClasspathConfiguration(configuration) || container.getExcludedConfigurations().contains(configuration.getName()) || isCopyOfBomConfiguration(configuration)) {
+        if (!isClasspathConfiguration(configuration) || container.getExcludedConfigurations().get().contains(configuration.getName()) || isCopyOfBomConfiguration(configuration)) {
             return;
         }
 
@@ -98,8 +98,14 @@ public class ExtendRecommenderConfigurationAction implements Action<Configuratio
 
     private String getNameWithCopySuffix() {
         int count = this.copyCount.incrementAndGet();
-        String copyName = bom.getName() + "Copy";
-        return count == 1 ? copyName : copyName + count;
+        // Include project path to ensure uniqueness across composite builds and subprojects
+        // Replace colons with underscores to avoid configuration naming issues
+        String projectPathSuffix = project.getPath().replace(":", "_");
+        if (projectPathSuffix.isEmpty() || projectPathSuffix.equals("_")) {
+            projectPathSuffix = "root";
+        }
+        String copyName = bom.getName() + "Copy_" + projectPathSuffix;
+        return count == 1 ? copyName : copyName + "_" + count;
     }
 
     //we want to apply recommendation only into final resolvable configurations like `compileClasspath` or `runtimeClasspath` across all source sets.

--- a/src/main/groovy/netflix/nebula/dependency/recommender/RecommendationStrategyFactory.java
+++ b/src/main/groovy/netflix/nebula/dependency/recommender/RecommendationStrategyFactory.java
@@ -21,7 +21,7 @@ public class RecommendationStrategyFactory {
         if(recommendationStrategy == null) {
             try {
                 RecommendationProviderContainer recommendationProviderContainer = project.getExtensions().findByType(RecommendationProviderContainer.class);
-                recommendationStrategy = Objects.requireNonNull(recommendationProviderContainer).getStrategy().getStrategyClass().newInstance();
+                recommendationStrategy = Objects.requireNonNull(recommendationProviderContainer).getStrategy().get().getStrategyClass().newInstance();
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }

--- a/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginConfigurationCacheSpec.groovy
+++ b/src/test/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPluginConfigurationCacheSpec.groovy
@@ -58,4 +58,134 @@ class DependencyRecommendationsPluginConfigurationCacheSpec extends IntegrationT
         runTasks('--configuration-cache', 'dependencies')
     }
 
+    def 'strictMode property works with configuration cache'() {
+        def repo = new MavenRepo()
+        repo.root = new File(projectDir, 'build/bomrepo')
+        def pom = new Pom('test.nebula.bom', 'testbom', '1.0.0', ArtifactType.POM)
+        pom.addManagementDependency('test.nebula', 'foo', '1.0.0')
+        repo.poms.add(pom)
+        repo.generate()
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:foo:1.0.0')
+                .build()
+        def generator = new GradleDependencyGenerator(graph)
+        generator.generateTestMavenRepo()
+
+        buildFile << """\
+            plugins {
+                id 'com.netflix.nebula.dependency-recommender'
+                id 'java'
+            }
+
+            repositories {
+                maven { url = '${repo.root.absoluteFile.toURI()}' }
+                ${generator.mavenRepositoryBlock}
+            }
+
+            dependencyRecommendations {
+                strictMode.set(false)
+            }
+
+            dependencies {
+                nebulaRecommenderBom 'test.nebula.bom:testbom:1.0.0@pom'
+                implementation 'test.nebula:foo'
+            }
+            """.stripIndent()
+
+        when:
+        def result1 = runTasks('--configuration-cache', 'dependencies')
+        def result2 = runTasks('--configuration-cache', 'dependencies')
+
+        then:
+        result1.output.contains('Calculating task graph')
+        result2.output.contains('Reusing configuration cache')
+    }
+
+    def 'eagerlyResolve property works with configuration cache'() {
+        def repo = new MavenRepo()
+        repo.root = new File(projectDir, 'build/bomrepo')
+        def pom = new Pom('test.nebula.bom', 'testbom', '1.0.0', ArtifactType.POM)
+        pom.addManagementDependency('test.nebula', 'foo', '1.0.0')
+        repo.poms.add(pom)
+        repo.generate()
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:foo:1.0.0')
+                .build()
+        def generator = new GradleDependencyGenerator(graph)
+        generator.generateTestMavenRepo()
+
+        buildFile << """\
+            plugins {
+                id 'com.netflix.nebula.dependency-recommender'
+                id 'java'
+            }
+
+            repositories {
+                maven { url = '${repo.root.absoluteFile.toURI()}' }
+                ${generator.mavenRepositoryBlock}
+            }
+
+            dependencyRecommendations {
+                eagerlyResolve.set(true)
+            }
+
+            dependencies {
+                nebulaRecommenderBom 'test.nebula.bom:testbom:1.0.0@pom'
+                implementation 'test.nebula:foo'
+            }
+            """.stripIndent()
+
+        when:
+        def result1 = runTasks('--configuration-cache', 'dependencies')
+        def result2 = runTasks('--configuration-cache', 'dependencies')
+
+        then:
+        result1.output.contains('Calculating task graph')
+        result2.output.contains('Reusing configuration cache')
+    }
+
+    def 'excludedConfigurations SetProperty works with configuration cache'() {
+        def repo = new MavenRepo()
+        repo.root = new File(projectDir, 'build/bomrepo')
+        def pom = new Pom('test.nebula.bom', 'testbom', '1.0.0', ArtifactType.POM)
+        pom.addManagementDependency('test.nebula', 'foo', '1.0.0')
+        repo.poms.add(pom)
+        repo.generate()
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:foo:1.0.0')
+                .build()
+        def generator = new GradleDependencyGenerator(graph)
+        generator.generateTestMavenRepo()
+
+        buildFile << """\
+            plugins {
+                id 'com.netflix.nebula.dependency-recommender'
+                id 'java'
+            }
+
+            repositories {
+                maven { url = '${repo.root.absoluteFile.toURI()}' }
+                ${generator.mavenRepositoryBlock}
+            }
+
+            dependencyRecommendations {
+                excludedConfigurations.add('testCompileClasspath')
+                excludedConfigurationPrefixes.add('test')
+            }
+
+            dependencies {
+                nebulaRecommenderBom 'test.nebula.bom:testbom:1.0.0@pom'
+                implementation 'test.nebula:foo'
+            }
+            """.stripIndent()
+
+        when:
+        def result1 = runTasks('--configuration-cache', 'dependencies')
+        def result2 = runTasks('--configuration-cache', 'dependencies')
+
+        then:
+        result1.output.contains('Calculating task graph')
+        result2.output.contains('Reusing configuration cache')
+    }
+
 }


### PR DESCRIPTION
* Remove reflection-based compatibility code:  The fallback to deprecated `getProjectConfiguration()` was for Gradle < 3.4 (from 2017)
* Configuration copies now include project path to prevent naming collisions
* Extension properties now use `Property<T>` and `SetProperty<String>` types
* Added deprecated convenience setters for backward compatibility that guide users to the new API